### PR TITLE
Fixed typo

### DIFF
--- a/pixel-cleanup.sketchplugin/Contents/Sketch/cleanup.cocoascript
+++ b/pixel-cleanup.sketchplugin/Contents/Sketch/cleanup.cocoascript
@@ -13,7 +13,7 @@ var onRun = function (context) {
     if (parentGroup) {
       cleanupGroup(parentGroup);
     }
-    doc.currentPage.deselectAllLayers();
+    doc.currentPage().deselectAllLayers();
     selection.select_byExpandingSelection(true,true);
   }
 


### PR DESCRIPTION
doc.currentPage is a method, so doc.currentPage.deselectAllLayers()
was throwing an error (you need to do doc.currentPage().deselectAllLayers)
